### PR TITLE
Fix format avoiding blank lines and fix PLUGIN_UPSTREAM variable check

### DIFF
--- a/coredns/Corefile.tmpl
+++ b/coredns/Corefile.tmpl
@@ -1,37 +1,37 @@
 .:{{ getenv "PUBLISH_PORT" }} {
-	{{ if gt (len (getenv "PLUGIN_FORWARDS")) 0 }}
-	proxy . {{ $addr := split (getenv "PLUGIN_FORWARDS") "," }}{{ range $addr }} {{ . }} {{ end }}
-	{{ end }}
-	etcd {{ $zone := split (getenv "PLUGIN_ZONES") "," }} {{ range $zone }} {{ . }} {{ end }} {
-		stubzones
-		path {{ getenv "PLUGIN_ROOT_PATH" }}
-		endpoint {{ $endpoint := split (getenv "PLUGIN_ETCD_ENDPOINTS") "," }} {{ range $endpoint }} {{ . }} {{ end }}
-		{{ if exists (getenv "PLUGIN_UPSTREAM") }}
-		upstream {{ getenv "PLUGIN_UPSTREAM" }}
-		{{ end }}
-	}
-	{{ if eq (getenv "PLUGIN_LOADBALANCE") "true" }}
-	loadbalance round_robin
-	{{ end }}
-	{{ if eq (getenv "PLUGIN_LOG") "true" }}
-	log
-	{{ end }}
-	{{ if eq (getenv "PLUGIN_ERRORS") "true" }}
-	errors
-	{{ end }}
-	{{ if eq (getenv "PLUGIN_HEALTH") "true" }}
-	health
-	{{ end }}
-	{{ if eq (getenv "PLUGIN_PROM") "true" }}
-	prometheus 0.0.0.0:9153
-	{{ end }}
-	{{ if eq (getenv "PLUGIN_PROXY") "true" }}
-	proxy . /etc/resolv.conf
-	{{ end }}
-	{{ if eq (getenv "PLUGIN_CACHE") "true" }}
-	cache 30
-	{{ end }}
-        {{ if gt (len (getenv "PLUGIN_REVERSES")) 0 }}
-	{{ getenv "PLUGIN_REVERSES" }}
-	{{ end }}
+    {{- if gt (len (getenv "PLUGIN_FORWARDS")) 0 }}
+    proxy . {{ $addr := split (getenv "PLUGIN_FORWARDS") "," }}{{ range $addr }} {{ . }} {{ end }}
+    {{- end }}
+    etcd {{ $zone := split (getenv "PLUGIN_ZONES") "," }} {{ range $zone }} {{ . }} {{ end }} {
+        stubzones
+        path {{ getenv "PLUGIN_ROOT_PATH" }}
+        endpoint {{ $endpoint := split (getenv "PLUGIN_ETCD_ENDPOINTS") "," }} {{ range $endpoint }} {{ . }} {{ end }}
+        {{- if gt (len (getenv "PLUGIN_UPSTREAM")) 0 }}
+        upstream {{ getenv "PLUGIN_UPSTREAM" }}
+        {{- end }}
+    }
+    {{- if eq (getenv "PLUGIN_LOADBALANCE") "true"}}
+    loadbalance round_robin
+    {{- end}}
+    {{- if eq (getenv "PLUGIN_LOG") "true"}}
+    log
+    {{- end}}
+    {{- if eq (getenv "PLUGIN_ERRORS") "true"}}
+    errors
+    {{- end}}
+    {{- if eq (getenv "PLUGIN_HEALTH") "true"}}
+    health
+    {{- end}}
+    {{- if eq (getenv "PLUGIN_PROM") "true"}}
+    prometheus 0.0.0.0:9153
+    {{- end}}
+    {{- if eq (getenv "PLUGIN_PROXY") "true"}}
+    proxy . /etc/resolv.conf
+    {{- end}}
+    {{- if eq (getenv "PLUGIN_CACHE") "true"}}
+    cache 30
+    {{- end}}
+    {{- if gt (len (getenv "PLUGIN_REVERSES")) 0}}
+    {{ getenv "PLUGIN_REVERSES" }}
+    {{- end}}
 }


### PR DESCRIPTION
This PR fix format avoiding blank lines and fix PLUGIN_UPSTREAM variable check.

generated file will be..
```
.:5353 {
    proxy .  8.8.8.8:53  8.8.4.4:53
    etcd   rancher.io  {
        stubzones
        path /skydns
        endpoint   http://etcd.etcd-ha:2379
        upstream /etc/resolv.conf
    }
    loadbalance round_robin
    log
    errors
    health
    prometheus 0.0.0.0:9153
    proxy . /etc/resolv.conf
    cache 30
}
```
instead...
```
.:5353 {

        proxy .  8.8.8.8:53  8.8.4.4:53

        etcd   rancher.io  {
                stubzones
                path /skydns
                endpoint   http://etcd.etcd-ha:2379

        }

        loadbalance round_robin


        log


        errors


        health


        prometheus 0.0.0.0:9153


        proxy . /etc/resolv.conf


        cache 30


}
```